### PR TITLE
more accurate replacement for utf8_encode and utf8_decode

### DIFF
--- a/standard/basic.php
+++ b/standard/basic.php
@@ -81,7 +81,7 @@ function is_iterable(mixed $value): bool {}
  * @deprecated 8.2 Consider to use {@link mb_convert_encoding}, {@link UConverter::transcode()} or {@link iconv()}
  */
 #[Pure]
-#[Deprecated(replacement: "mb_convert_encoding(%parameter0%, 'UTF-8')", since: "8.2")]
+#[Deprecated(replacement: "mb_convert_encoding(%parameter0%, 'UTF-8', 'ISO-8859-1')", since: "8.2")]
 function utf8_encode(string $string): string {}
 
 /**
@@ -95,7 +95,7 @@ function utf8_encode(string $string): string {}
  * @deprecated 8.2 Consider to use {@link mb_convert_encoding}, {@link UConverter::transcode()} or {@link iconv()}
  */
 #[Pure]
-#[Deprecated(replacement: "mb_convert_encoding(%parameter0%, 'ISO-8859-1')", since: "8.2")]
+#[Deprecated(replacement: "mb_convert_encoding(%parameter0%, 'ISO-8859-1', 'UTF-8')", since: "8.2")]
 function utf8_decode(string $string): string {}
 
 /**


### PR DESCRIPTION
The problem is that both deprecated functions convert unconditionally between utf-8 and iso-8859-1. But mb_convert_encoding works differently if the from_encoding parameter is missing: " If from_encoding is omitted or null, the mbstring.internal_encoding setting will be used if set, otherwise the default_charset setting."